### PR TITLE
Use ware to support async parsing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
   "license": "MIT",
   "dependencies": {
     "parse-latin": "^0.1.0-rc.6",
-    "textom": "^0.1.0-rc.3"
+    "textom": "^0.1.0-rc.3",
+    "ware": "git@github.com:segmentio/ware.git#1.0.1"
   },
   "main": "index.js",
   "ignore": [

--- a/component.json
+++ b/component.json
@@ -13,6 +13,7 @@
     "textom"
   ],
   "dependencies": {
+    "segmentio/ware": "^1.0.1",
     "wooorm/parse-latin": "^0.1.0-rc.6",
     "wooorm/textom": "^0.1.0-rc.3"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "parse-latin": "^0.1.0-rc.6",
-    "textom": "^0.1.0-rc.3"
+    "textom": "^0.1.0-rc.3",
+    "ware": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^0.8.0",


### PR DESCRIPTION
Figured I'd throw in what it'd look like if retext supported async parsing middleware. One ability of parsing asynchronously is to query external datasets against words or phases during parsing. By using [ware](https://github.com/segmentio/ware), we can also abstract the logic of supporting various async flows.
