### PR TITLE
Add `retext-case-police` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -24,6 +24,8 @@ The list of plugins:
 
 *   [`retext-assuming`](https://github.com/davidhund/retext-assuming)
     — check for unhelpful phrases such as `just`, `simply`, `obviously`
+*   [`retext-case-police`](https://github.com/JulianCataldo/retext-case-police)
+    — check for popular names casing (`github` → `GitHub`)
 *   [`retext-cliches`](https://github.com/dunckr/retext-cliches)
     — check phrases for cliches
 *   [`retext-contractions`](https://github.com/retextjs/retext-contractions)
@@ -73,7 +75,7 @@ The list of plugins:
 *   [`retext-syntax-mentions`](https://github.com/retextjs/retext-syntax-mentions)
     — classify `@mentions` as syntax
 *   [`retext-syntax-urls`](https://github.com/retextjs/retext-syntax-urls)
-    — Classify url-like values (example.com, example.md, etc) as syntax
+    — classify url-like values (example.com, example.md, etc) as syntax
 *   [`retext-usage`](https://github.com/admhlt/retext-usage)
     — check incorrect English usage
 *   [`retext-quotes`](https://github.com/retextjs/retext-quotes)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

[Repository](https://github.com/JulianCataldo/retext-case-police)

A `retext` plugin for checking popular names casing.

Examples:

- ⚠️ `macbook` → ✅ **`MacBook`**
- ⚠️ `MacOS` → ✅ **`macOS`**


For:

- [Abbreviates](https://github.com/antfu/case-police/blob/main/dict/abbreviates.json)
- [Brands](https://github.com/antfu/case-police/blob/main/dict/brands.json)
- [General](https://github.com/antfu/case-police/blob/main/dict/general.json)
- [Products](https://github.com/antfu/case-police/blob/main/dict/products.json)
- [Softwares](https://github.com/antfu/case-police/blob/main/dict/softwares.json)

---

Dictionaries are from [`case-police`](https://github.com/antfu/case-police).

<!--do not edit: pr-->
