### PR TITLE
Add `retext-lexrank` to list of plugins

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -48,6 +48,8 @@ The list of plugins:
     — extract keywords and keyphrases
 *   [`retext-latin`](https://github.com/retextjs/retext/tree/main/packages/retext-latin)
     — Latin-script language support
+*   [`retext-lexrank`](https://github.com/gorango/retext-lexrank)
+    — add Lexrank scores to sentences
 *   [`retext-overuse`](https://github.com/dunckr/retext-overuse)
     — check words for overuse
 *   [`retext-passive`](https://github.com/retextjs/retext-passive)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

A `retext` plugin for generating unsupervised text summarization using the [Lexrank algorithm](https://arxiv.org/abs/1109.2128).

<!--do not edit: pr-->
