### PR TITLE
Update `parse-latin`, `parse-english`, `parse-dutch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,13 @@
     }
   },
   "remarkConfig": {
+    "To do": "enable `remark-retext` after major",
     "plugins": [
-      "preset-wooorm"
+      "remark-preset-wooorm",
+      [
+        "remark-retext",
+        false
+      ]
     ]
   },
   "typeCoverage": {

--- a/packages/retext-dutch/lib/index.js
+++ b/packages/retext-dutch/lib/index.js
@@ -3,7 +3,6 @@
  */
 
 import {unherit} from 'unherit'
-// @ts-expect-error: untyped.
 import {ParseDutch} from 'parse-dutch'
 
 /**
@@ -14,5 +13,4 @@ export default function retextDutch() {
   Object.assign(this, {Parser: unherit(ParseDutch)})
 }
 
-// @ts-expect-error: untyped.
 export {ParseDutch as Parser} from 'parse-dutch'

--- a/packages/retext-dutch/package.json
+++ b/packages/retext-dutch/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@types/nlcst": "^1.0.0",
-    "parse-dutch": "^5.0.0",
+    "parse-dutch": "^6.0.0",
     "unherit": "^3.0.0",
     "unified": "^10.0.0"
   },

--- a/packages/retext-english/lib/index.js
+++ b/packages/retext-english/lib/index.js
@@ -3,7 +3,6 @@
  */
 
 import {unherit} from 'unherit'
-// @ts-expect-error: untyped.
 import {ParseEnglish} from 'parse-english'
 
 /**
@@ -14,5 +13,4 @@ export default function retextEnglish() {
   Object.assign(this, {Parser: unherit(ParseEnglish)})
 }
 
-// @ts-expect-error: untyped.
 export {ParseEnglish as Parser} from 'parse-english'

--- a/packages/retext-english/package.json
+++ b/packages/retext-english/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@types/nlcst": "^1.0.0",
-    "parse-english": "^5.0.0",
+    "parse-english": "^6.0.0",
     "unherit": "^3.0.0",
     "unified": "^10.0.0"
   },

--- a/packages/retext-latin/lib/index.js
+++ b/packages/retext-latin/lib/index.js
@@ -3,7 +3,6 @@
  */
 
 import {unherit} from 'unherit'
-// @ts-expect-error: untyped.
 import {ParseLatin} from 'parse-latin'
 
 /**
@@ -14,5 +13,4 @@ export default function retextLatin() {
   Object.assign(this, {Parser: unherit(ParseLatin)})
 }
 
-// @ts-expect-error: untyped.
 export {ParseLatin as Parser} from 'parse-latin'

--- a/packages/retext-latin/package.json
+++ b/packages/retext-latin/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@types/nlcst": "^1.0.0",
-    "parse-latin": "^5.0.0",
+    "parse-latin": "^6.0.0",
     "unherit": "^3.0.0",
     "unified": "^10.0.0"
   },


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This updates `parse-latin`, `parse-english`, `parse-dutch`, to versions that include types. And clean their APIs.
This is a major as it will break several plugins as of now. They will need updating.

<!--do not edit: pr-->
